### PR TITLE
[#9] 통합 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	testImplementation 'io.rest-assured:rest-assured'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/jindo/minipay/account/checking/repository/CheckingAccountRepository.java
+++ b/src/main/java/com/jindo/minipay/account/checking/repository/CheckingAccountRepository.java
@@ -2,6 +2,7 @@ package com.jindo.minipay.account.checking.repository;
 
 import com.jindo.minipay.account.checking.entity.CheckingAccount;
 import com.jindo.minipay.account.common.repository.AccountRepository;
+import com.jindo.minipay.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,4 +12,6 @@ public interface CheckingAccountRepository extends JpaRepository<CheckingAccount
     boolean existsByAccountNumber(String accountNumber);
 
     Optional<CheckingAccount> findByAccountNumber(String accountNumber);
+
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/jindo/minipay/account/saving/repository/SavingAccountRepository.java
+++ b/src/main/java/com/jindo/minipay/account/saving/repository/SavingAccountRepository.java
@@ -2,6 +2,7 @@ package com.jindo.minipay.account.saving.repository;
 
 import com.jindo.minipay.account.common.repository.AccountRepository;
 import com.jindo.minipay.account.saving.entity.SavingAccount;
+import com.jindo.minipay.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,4 +12,6 @@ public interface SavingAccountRepository extends JpaRepository<SavingAccount, Lo
     boolean existsByAccountNumber(String accountNumber);
 
     Optional<SavingAccount> findByAccountNumber(String accountNumber);
+
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/jindo/minipay/lock/aop/CustomTransactionSynchronization.java
+++ b/src/main/java/com/jindo/minipay/lock/aop/CustomTransactionSynchronization.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
-public class CustomTransactionSynchronization  implements TransactionSynchronization {
+public class CustomTransactionSynchronization implements TransactionSynchronization {
     private final LockService lockService;
     private final String key;
     private final List<String> keys;

--- a/src/main/java/com/jindo/minipay/member/repository/MemberRepository.java
+++ b/src/main/java/com/jindo/minipay/member/repository/MemberRepository.java
@@ -4,9 +4,12 @@ import com.jindo.minipay.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     List<Member> findByIdIn(List<Long> ids);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/jindo/minipay/settlements/dto/SettleCalculateResponse.java
+++ b/src/main/java/com/jindo/minipay/settlements/dto/SettleCalculateResponse.java
@@ -1,5 +1,7 @@
 package com.jindo.minipay.settlements.dto;
 
+import com.jindo.minipay.global.exception.ErrorCode;
+import com.jindo.minipay.settlements.exception.SettlementException;
 import com.jindo.minipay.settlements.type.SettlementType;
 import lombok.Builder;
 
@@ -20,6 +22,11 @@ public record SettleCalculateResponse(
         long remainingAmount = 0;
         if (settlementType == SettlementType.DUTCH_PAY) {
             remainingAmount = totalAmount % numOfParticipants;
+        }
+
+        long sumOfRequest = requestAmounts.stream().mapToLong(o -> o).sum();
+        if (sumOfRequest + remainingAmount != totalAmount) {
+            throw new SettlementException(ErrorCode.INCORRECT_TOTAL_AMOUNT);
         }
 
         return SettleCalculateResponse.builder()

--- a/src/main/java/com/jindo/minipay/settlements/service/SettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlements/service/SettlementService.java
@@ -60,15 +60,6 @@ public class SettlementService {
         if (request.numOfParticipants() > request.totalAmount()) {
             throw new SettlementException(INSUFFICIENT_SETTLE_AMOUNT);
         }
-
-        // totalAmount 확인
-        Long sumAmount = request.participants().stream()
-                .mapToLong(SettleAccountsRequest.ParticipantRequest::requestAmount)
-                .sum();
-
-        if (!sumAmount.equals(request.totalAmount())) {
-            throw new SettlementException(INCORRECT_TOTAL_AMOUNT);
-        }
     }
 
     private List<Member> getParticipantsOrThrow(SettleAccountsRequest request) {

--- a/src/test/java/com/jindo/minipay/account/saving/controller/SavingAccountControllerTest.java
+++ b/src/test/java/com/jindo/minipay/account/saving/controller/SavingAccountControllerTest.java
@@ -16,8 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(SavingAccountController.class)
 class SavingAccountControllerTest {
@@ -45,6 +44,7 @@ class SavingAccountControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
                 .andDo(print());
     }
 

--- a/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-//@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @Disabled
 @ActiveProfiles("test")
 @AutoConfigureMockMvc

--- a/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
 @Disabled
 @ActiveProfiles("test")
-@AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class BaseIntegrationTest {
     @LocalServerPort

--- a/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/BaseIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.jindo.minipay.integration;
+
+import com.jindo.minipay.account.checking.entity.CheckingAccount;
+import com.jindo.minipay.account.checking.repository.CheckingAccountRepository;
+import com.jindo.minipay.account.saving.repository.SavingAccountRepository;
+import com.jindo.minipay.member.entity.Member;
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlements.repository.SettlementParticipantRepository;
+import com.jindo.minipay.settlements.repository.SettlementRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+//@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Disabled
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class BaseIntegrationTest {
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected CheckingAccountRepository checkingAccountRepository;
+
+    @Autowired
+    protected SavingAccountRepository savingAccountRepository;
+
+    @Autowired
+    protected SettlementRepository settlementRepository;
+
+    @Autowired
+    protected SettlementParticipantRepository settlementParticipantRepository;
+
+    @BeforeEach
+    void setup() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    void teardown() {
+        settlementParticipantRepository.deleteAllInBatch();
+        settlementRepository.deleteAllInBatch();
+        savingAccountRepository.deleteAllInBatch();
+        checkingAccountRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    protected Member saveMember() {
+        Member member = Member.builder()
+                .email("test@test.com")
+                .password("test12345")
+                .name("tester1")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    protected void saveCheckingAccount(Member member) {
+        CheckingAccount account =
+                CheckingAccount.of("8888-01-1234567", member);
+        checkingAccountRepository.save(account);
+    }
+}

--- a/src/test/java/com/jindo/minipay/integration/account/CheckingAccountIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/account/CheckingAccountIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("메인 계좌 통합테스트")
-public class CheckingAccountIntegrationTest extends BaseIntegrationTest {
+class CheckingAccountIntegrationTest extends BaseIntegrationTest {
     static final String URL = "/api/v1/account/checking";
 
     @Test

--- a/src/test/java/com/jindo/minipay/integration/account/CheckingAccountIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/account/CheckingAccountIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.jindo.minipay.integration.account;
+
+import com.jindo.minipay.account.checking.dto.ChargeRequest;
+import com.jindo.minipay.account.checking.dto.RemitRequest;
+import com.jindo.minipay.account.checking.entity.CheckingAccount;
+import com.jindo.minipay.integration.BaseIntegrationTest;
+import com.jindo.minipay.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("메인 계좌 통합테스트")
+public class CheckingAccountIntegrationTest extends BaseIntegrationTest {
+    static final String URL = "/api/v1/account/checking";
+
+    @Test
+    @DisplayName("메인 계좌에 충전한다.")
+    void charge() {
+        // given
+        Member member = saveMember();
+        saveCheckingAccount(member);
+
+        String accountNumber = "8888-01-1234567";
+        ChargeRequest request = new ChargeRequest(accountNumber, 10000L);
+
+        // when
+        // then
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL + "/charge")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("accountNumber", equalTo(accountNumber))
+                .body("balance", equalTo(10000))
+                .log().all();
+    }
+
+    @Test
+    @DisplayName("메인 계좌에서 친구 계좌로 송금한다.")
+    void remit() {
+        // given
+        Member member = saveMember();
+        saveCheckingAccount(member);
+
+        saveFriendAndAccount();
+
+        String myAccountNumber = "8888-01-1234567";
+        String receiverAccountNumber = "8888-02-7654321";
+
+        RemitRequest request = RemitRequest.builder()
+                .myAccountNumber(myAccountNumber)
+                .receiverAccountNumber(receiverAccountNumber)
+                .amount(10000L)
+                .build();
+
+        // when
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL + "/remit")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("accountNumber", equalTo(myAccountNumber))
+                .body("balance", equalTo(0))
+                .log().all();
+
+        // then
+        Optional<CheckingAccount> receiverAccount =
+                checkingAccountRepository.findByAccountNumber(receiverAccountNumber);
+
+        assertTrue(receiverAccount.isPresent());
+        assertEquals(10000L, receiverAccount.get().getBalance());
+    }
+
+    void saveFriendAndAccount() {
+        Member member = Member.builder()
+                .email("friend@test.com")
+                .password("test12345")
+                .name("tester2")
+                .build();
+        memberRepository.save(member);
+
+        CheckingAccount account =
+                CheckingAccount.of("8888-02-7654321", member);
+        checkingAccountRepository.save(account);
+    }
+}

--- a/src/test/java/com/jindo/minipay/integration/account/SavingAccountIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/account/SavingAccountIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.jindo.minipay.integration.account;
+
+import com.jindo.minipay.account.checking.entity.CheckingAccount;
+import com.jindo.minipay.account.saving.dto.CreateSavingAccountRequest;
+import com.jindo.minipay.account.saving.dto.PayInRequest;
+import com.jindo.minipay.account.saving.entity.SavingAccount;
+import com.jindo.minipay.integration.BaseIntegrationTest;
+import com.jindo.minipay.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("적금 계좌 통합테스트")
+public class SavingAccountIntegrationTest extends BaseIntegrationTest {
+    static final String URL = "/api/v1/account/saving";
+
+    @Test
+    @DisplayName("적금 계좌를 생성한다.")
+    void create() {
+        // given
+        Member member = saveMember();
+
+        CreateSavingAccountRequest request =
+                new CreateSavingAccountRequest(member.getId());
+
+        // when
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL)
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .log().all();
+
+        // then
+        assertTrue(savingAccountRepository.existsByMember(member));
+    }
+
+    @Test
+    @DisplayName("적금 계좌에 납입한다.")
+    void payIn() {
+        // given
+        Member member = saveMember();
+        saveSavingAccountAndCheckingAccount(member);
+
+        String savingAccountNumber = "8800-01-1234567";
+        String checkingAccountNumber = "8888-01-1234567";
+
+        PayInRequest request = new PayInRequest(savingAccountNumber,
+                checkingAccountNumber, 10000L);
+
+        // when
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL + "/payin")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("accountNumber", equalTo(savingAccountNumber))
+                .body("amount", equalTo(10000))
+                .log().all();
+
+        // then
+        Optional<SavingAccount> savingAccount =
+                savingAccountRepository.findByAccountNumber(savingAccountNumber);
+
+        assertTrue(savingAccount.isPresent());
+        assertEquals(10000, savingAccount.get().getAmount());
+    }
+
+    void saveSavingAccountAndCheckingAccount(Member member) {
+        SavingAccount savingAccount =
+                SavingAccount.of("8800-01-1234567", member);
+        savingAccountRepository.save(savingAccount);
+
+        CheckingAccount checkingAccount =
+                CheckingAccount.of("8888-01-1234567", member);
+        checkingAccount.increaseBalance(10000L);
+        checkingAccountRepository.save(checkingAccount);
+    }
+}

--- a/src/test/java/com/jindo/minipay/integration/account/SavingAccountIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/account/SavingAccountIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("적금 계좌 통합테스트")
-public class SavingAccountIntegrationTest extends BaseIntegrationTest {
+class SavingAccountIntegrationTest extends BaseIntegrationTest {
     static final String URL = "/api/v1/account/saving";
 
     @Test

--- a/src/test/java/com/jindo/minipay/integration/member/MemberIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/member/MemberIntegrationTest.java
@@ -13,7 +13,7 @@ import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("회원 통합테스트")
-public class MemberIntegrationTest extends BaseIntegrationTest {
+class MemberIntegrationTest extends BaseIntegrationTest {
     static final String URL = "/api/v1/members";
 
     @Test

--- a/src/test/java/com/jindo/minipay/integration/member/MemberIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/member/MemberIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.jindo.minipay.integration.member;
+
+import com.jindo.minipay.integration.BaseIntegrationTest;
+import com.jindo.minipay.member.dto.RegisterRequest;
+import com.jindo.minipay.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("회원 통합테스트")
+public class MemberIntegrationTest extends BaseIntegrationTest {
+    static final String URL = "/api/v1/members";
+
+    @Test
+    @DisplayName("회원을 등록한다.")
+    void register() {
+        // given
+        String email = "test@test.com";
+
+        RegisterRequest request = RegisterRequest.builder()
+                .email(email)
+                .password("test12345")
+                .name("tester1")
+                .build();
+
+        // when
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post(URL)
+                .then().log().all();
+
+        // then
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+
+        assertTrue(memberOptional.isPresent());
+        assertTrue(checkingAccountRepository.existsByMember(memberOptional.get()));
+    }
+}

--- a/src/test/java/com/jindo/minipay/integration/settlement/SettlementIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/settlement/SettlementIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.jindo.minipay.integration.settlement;
+
+import com.jindo.minipay.integration.BaseIntegrationTest;
+import com.jindo.minipay.member.entity.Member;
+import com.jindo.minipay.settlements.dto.SettleAccountsRequest;
+import com.jindo.minipay.settlements.dto.SettleCalculateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@DisplayName("정산 통합테스트")
+public class SettlementIntegrationTest extends BaseIntegrationTest {
+    static final String URL = "/api/v1/settlements";
+
+    @Test
+    @DisplayName("[더치패이] 정산 금액을 계산한다.")
+    void settleCalculate_dutchPay() {
+        // given
+        Member member = saveMember();
+
+        SettleCalculateRequest request = SettleCalculateRequest.builder()
+                .settlementType("DUTCH_PAY")
+                .totalAmount(35000L)
+                .numOfParticipants(3)
+                .requesterId(member.getId())
+                .build();
+
+        // when
+        // then
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL + "/calculate")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .body("settlementType", equalTo("DUTCH_PAY"))
+                .body("numOfParticipants", equalTo(3))
+                .body("totalAmount", equalTo(35000))
+                .body("requestAmounts[0]", is(11666))
+                .body("requestAmounts[1]", is(11666))
+                .body("requestAmounts[2]", is(11666))
+                .body("remainingAmount", equalTo(2))
+                .log().all();
+    }
+
+    @Test
+    @DisplayName("[랜덤] 정산 금액을 계산한다.")
+    void settleCalculate_random() {
+        // given
+        Member member = saveMember();
+
+        SettleCalculateRequest request = SettleCalculateRequest.builder()
+                .settlementType("RANDOM")
+                .totalAmount(35000L)
+                .numOfParticipants(3)
+                .requesterId(member.getId())
+                .build();
+
+        // when
+        // then
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL + "/calculate")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .body("settlementType", equalTo("RANDOM"))
+                .body("numOfParticipants", equalTo(3))
+                .body("totalAmount", equalTo(35000))
+                .body("requestAmounts", hasSize(3))
+                .body("remainingAmount", equalTo(0))
+                .log().all();
+    }
+
+    @Test
+    @DisplayName("정산을 요청한다.")
+    void settleAccounts() {
+        // given
+        Member member = saveMember();
+
+        List<Member> participants = saveParticipants();
+
+        SettleAccountsRequest request = SettleAccountsRequest.builder()
+                .settlementType("RANDOM")
+                .totalAmount(35000L)
+                .numOfParticipants(2)
+                .requesterId(member.getId())
+                .participants(List.of(
+                        new SettleAccountsRequest
+                                .ParticipantRequest(participants.get(0).getId(),
+                                10000L),
+                        new SettleAccountsRequest
+                                .ParticipantRequest(participants.get(1).getId(),
+                                25000L)))
+                .remainingAmount(0)
+                .build();
+
+        // when
+        // then
+        given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(URL)
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .body("settlementType", equalTo("RANDOM"))
+                .body("totalAmount", equalTo(35000))
+                .body("numOfParticipants", equalTo(2))
+                .body("participants", hasSize(2))
+                .body("remainingAmount", equalTo(0))
+                .body("settlementStatus", equalTo("WAITING"))
+                .log().all();
+    }
+
+    List<Member> saveParticipants() {
+        List<Member> partsMembers = new ArrayList<>();
+
+        Member participant1 = Member.builder()
+                .email("part1@test.com")
+                .password("test12345")
+                .name("part1")
+                .build();
+
+        Member participant2 = Member.builder()
+                .email("part2@test.com")
+                .password("test12345")
+                .name("part2")
+                .build();
+
+        partsMembers.add(memberRepository.save(participant1));
+        partsMembers.add(memberRepository.save(participant2));
+
+        return partsMembers;
+    }
+}

--- a/src/test/java/com/jindo/minipay/integration/settlement/SettlementIntegrationTest.java
+++ b/src/test/java/com/jindo/minipay/integration/settlement/SettlementIntegrationTest.java
@@ -16,7 +16,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @DisplayName("정산 통합테스트")
-public class SettlementIntegrationTest extends BaseIntegrationTest {
+class SettlementIntegrationTest extends BaseIntegrationTest {
     static final String URL = "/api/v1/settlements";
 
     @Test

--- a/src/test/java/com/jindo/minipay/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jindo/minipay/member/controller/MemberControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
@@ -46,6 +47,7 @@ class MemberControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/jindo/minipay/settlements/controller/SettlementControllerTest.java
+++ b/src/test/java/com/jindo/minipay/settlements/controller/SettlementControllerTest.java
@@ -48,7 +48,7 @@ class SettlementControllerTest {
 
         SettleCalculateResponse response = SettleCalculateResponse.builder()
                 .settlementType(SettlementType.DUTCH_PAY)
-                .numOfParticipants(2)
+                .numOfParticipants(3)
                 .totalAmount(35000L)
                 .requestAmounts(List.of(11666L, 11666L))
                 .remainingAmount(2)
@@ -66,7 +66,7 @@ class SettlementControllerTest {
                 .andExpect(jsonPath("$.settlementType")
                         .value("DUTCH_PAY"))
                 .andExpect(jsonPath("$.numOfParticipants")
-                        .value(2))
+                        .value(3))
                 .andExpect(jsonPath("$.totalAmount")
                         .value(35000))
                 .andExpect(jsonPath("$.requestAmounts[0]")

--- a/src/test/java/com/jindo/minipay/settlements/service/SettlementServiceTest.java
+++ b/src/test/java/com/jindo/minipay/settlements/service/SettlementServiceTest.java
@@ -185,26 +185,14 @@ class SettlementServiceTest {
                     .save(any());
         }
 
-        static Stream<Arguments> provideRequest() {
-            return Stream.of(
-                    Arguments.of(10L, 12,
-                            INSUFFICIENT_SETTLE_AMOUNT.getMessage()),
-                    Arguments.of(100000L, 2,
-                            INCORRECT_TOTAL_AMOUNT.getMessage())
-            );
-        }
-
-        @ParameterizedTest
-        @MethodSource("provideRequest")
-        @DisplayName("정산 금액보다 정산 인원수가 많거나 정산 금액이 요청 금액의 합과 맞지 않으면 예외가 발생한다.")
-        void settleAccounts_invalid_request(Long totalAmount,
-                                            int numOfParticipants,
-                                            String errorMessage) {
+        @Test
+        @DisplayName("정산 금액보다 정산 인원수가 많으면 예외가 발생한다.")
+        void settleAccounts_invalid_request() {
             // given
             SettleAccountsRequest request = SettleAccountsRequest.builder()
                     .settlementType("RANDOM")
-                    .totalAmount(totalAmount)
-                    .numOfParticipants(numOfParticipants)
+                    .totalAmount(10L)
+                    .numOfParticipants(12)
                     .requesterId(1L)
                     .participants(List.of(new SettleAccountsRequest
                                     .ParticipantRequest(1L, 10000L),
@@ -217,7 +205,7 @@ class SettlementServiceTest {
             // then
             assertThatThrownBy(() -> settlementService.settleAccounts(request))
                     .isInstanceOf(SettlementException.class)
-                    .hasMessageContaining(errorMessage);
+                    .hasMessageContaining(INSUFFICIENT_SETTLE_AMOUNT.getMessage());
         }
 
         static Stream<Arguments> provideParticipants() {


### PR DESCRIPTION
[//]: # (PR 제목: [#이슈 번호] Step N. 제목)
# 변경 사항
## 통합 테스트 작성 배경
- 지금까지 개별 구성 요소의 동작을 검증하는 단위 테스트만 작성했습니다.
- 단위 테스트를 통해서 세밀하게 기능을 검증하는 것도 중요하지만, 단위 테스트만으로는 전체 시스템의 동작은 보장하지 않기 때문에 통합 테스트를 작성해보았습니다.

## 통합 테스트 환경
- 통합 테스트는 개발 환경에서 모듈 간의 통합을 검증하기 위한 테스트입니다. 그래서 실제 운영 환경과 동일하지 않아도 될 것으로 생각하여, 어떤 환경에서든 빠르게 동작할 수 있는 H2 Database, Embedded Redis 등 인메모리 환경으로 세팅하였습니다.
- 작성한 REST API가 잘 동작하는지 확인하기 위해 API를 테스트할 수 있도록 하는 [RestAssured](https://github.com/rest-assured/rest-assured/wiki/Usage) 라이브러리를 사용하였습니다.

### RestAssured
  - Request를 보내고 Response를 받고 미리 결정된 결과와 비교하는 black box 테스트로 동작됩니다.
  - 실제 web environment(Apache Tomcat)를 사용하여 테스트할 수 있는 테스트 클라이언트 입니다.
  - 참고) MockMvc는 @SpringBootTest의 webEnvironment.MOCK과 함께 사용하능하며, mocking된 web environment 환경에서 테스트하는 테스트 클라이언트입니다.

## 고민
1.
- web environment context를 처음 시작할 때 한번만 띄우기 때문에 테스트 수행 후 쌓인 데이터가 다음 테스트에 영향을 미치게 됩니다.
- 그래서 @AfterEach로 메서드 수행이 끝난 뒤 사용한 테이블을 deleteAllInBatch()로 해당 테이블의 전체 데이터를 한번에 삭제하도록 했습니다.
- 하지만 이렇게 처리했을 시 FK로 인해 삭제하는 테이블의 순서가 중요했습니다. 만약 서비스가 점차 커진다면 FK를 신경쓰면서 데이터를 정리해주는게 좋은 방법일지 고민됩니다.
- 그래서 delete보다는 truncate를 사용하도록 추후 변경하는 것이 좋아보입니다. (AUTO_INCREMENT ID도 1로 다시 초기화 되는 장점도 있음)

2.
- 현재 작성한 테스트는 통합 테스트라고 생각하고 작성했는데, REST API로 request, response를 검증하는 black box 테스트라서 E2E(End to End) 테스트라고 볼 수도 있을 것 같은데 그렇게 되면 테스트 환경을 운영 환경과 동일하게 구축하는게 좋을지 고민입니다.

## 회고
이번에 통합 테스트 작성하면서 비즈니스 로직의 버그를 찾았습니다.. 단위 테스트에서는 발견하지 못했던 부분인데 이번에 알게 돼서 테스트 코드 작성에 대한 중요성을 느낄 수 있었던 것 같네요.

## 관련 이슈
resolves #9 